### PR TITLE
Retroactively update the changelog for 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,16 @@ General updates:
   - Add `.nvmrc` with `lts/iron` (v20)
   - Use `dart-sass` instead of `node-sass`
   - Update dependencies to work with Node 20
-Features:
-- Add `utm_id` parameter handling
 
+## 1.1.0
+Features:
+- Yandex click ID handling (`yclid`)
+
+Fixes:
+- Avoid `-0` custom UTC offset value
+
+Changes:
+- Update dependencies
 
 ## 1.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,15 @@ Features:
 - Add `utm_id` parameter handling
 
 Changes:
-- Forked from the original repo (`alex35mil/sourcebuster-js`)
-
-General updates: 
-  - Add `.nvmrc` with `lts/iron` (v20)
-  - Use `dart-sass` instead of `node-sass`
-  - Update dependencies to work with Node 20
+- Fork from the original repo (`alex35mil/sourcebuster-js`)
+- Add `.nvmrc` with `lts/iron` (v20)
+- Use `dart-sass` instead of `node-sass`
+- Update dependencies to work with Node 20
 
 ## 1.1.0
 
 Features:
-- Yandex click ID handling (`yclid`)
+- Add Yandex click ID handling (`yclid`)
 
 Fixes:
 - Avoid `-0` custom UTC offset value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-
 ## 1.1.2
+
 Features:
 - Add `utm_id` parameter handling
 
@@ -12,6 +12,7 @@ General updates:
   - Update dependencies to work with Node 20
 
 ## 1.1.0
+
 Features:
 - Yandex click ID handling (`yclid`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+
+## 1.1.2
+Features:
+- Add `utm_id` parameter handling
+
+Changes:
+- Forked from the original repo (`alex35mil/sourcebuster-js`)
+
+General updates: 
+  - Add `.nvmrc` with `lts/iron` (v20)
+  - Use `dart-sass` instead of `node-sass`
+  - Update dependencies to work with Node 20
+Features:
+- Add `utm_id` parameter handling
+
+
 ## 1.0.5
 
 Features:


### PR DESCRIPTION
The changelog wasn't updated for the release of 1.1.2, so this PR adds those entries.

The log for 1.1.0 was also missing (https://github.com/alex35mil/sourcebuster-js/compare/v1.0.5...v1.1.0), so this adds those too.

What happened to 1.1.1? That's a good question... 🛸 